### PR TITLE
build(ci): added GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+    - name: Install libgeneral
+      run: |
+        git clone https://github.com/tihmstar/libgeneral.git
+        cd libgeneral
+        ./autogen.sh
+        make
+        sudo make install
     - name: autogen
       run: ./autogen.sh
     - name: make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,13 @@
+name: C/C++ CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: autogen
+      run: ./autogen.sh
+    - name: make
+      run: make
+    - name: make install
+      run: sudo make install

--- a/liboffsetfinder64/vmem.cpp
+++ b/liboffsetfinder64/vmem.cpp
@@ -6,6 +6,7 @@
 //  Copyright © 2019 tihmstar. All rights reserved.
 //
 
+#include <algorithm>
 #include "vmem.hpp"
 #include <libgeneral/macros.h>
 #include "OFexception.hpp"


### PR DESCRIPTION
Hey,

title says everything. The build is failing, because match-o is not available in ubuntu: https://github.com/mxschmitt/liboffsetfinder64/commit/d0c25139540e5f99480f06597b3ab5a55ff18af2/checks?check_suite_id=326541417#step:5:89

we could switch to a macOS build, what do you think?

Unfortunately the build is not triggering on this repo, so that's the URL of my fork: https://github.com/mxschmitt/liboffsetfinder64/commit/d0c25139540e5f99480f06597b3ab5a55ff18af2/checks?check_suite_id=326541417