### PR TITLE
Fix freshnonce patch for devices with a mov before the bl

### DIFF
--- a/libpatchfinder/ibootpatchfinder/ibootpatchfinder64_base.cpp
+++ b/libpatchfinder/ibootpatchfinder/ibootpatchfinder64_base.cpp
@@ -691,7 +691,7 @@ std::vector<patch> ibootpatchfinder64_base::get_freshnonce_patch(){
 
     vmem iter = _vmem->getIter(noncefun2_blref);
     
-    assure((--iter).supertype() == insn::sut_branch_imm);
+    assure((--iter).supertype() == insn::sut_branch_imm || (iter() == insn::movz && (--iter).supertype() == insn::sut_branch_imm));
 
     loc_t branchloc = iter;
     debug("branchloc=0x%016llx\n",branchloc);


### PR DESCRIPTION
Fix freshnonce patch for devices with a mov before the bl
Specifically a8x
<img width="621" alt="image" src="https://github.com/tihmstar/libpatchfinder/assets/27748705/d89197b8-5da3-44d5-8787-6c2d223a8916">
